### PR TITLE
fix: remove hardcoded import name

### DIFF
--- a/app/moduleLoader.tsx
+++ b/app/moduleLoader.tsx
@@ -32,7 +32,7 @@ function ModuleLoader({
   React.useEffect(() => {
     Promise.all(
       Object.keys(imports).map(async (importName) => ({
-        name: "react-flow-renderer",
+        name: importName,
         content: await imports[importName](),
       }))
     ).then(


### PR DESCRIPTION
The import name is hardcoded to `"react-flow-renderer"` which means that the example code from this repo won't work off the bat with other modules. 

For context, I'm looking at using this with [`react-force-graph-2d`](https://github.com/vasturiano/react-force-graph) and this fix made it work

Thanks for the workaround!